### PR TITLE
Fix Apply One Suggestion cursor column

### DIFF
--- a/lib/hlint-refactor.coffee
+++ b/lib/hlint-refactor.coffee
@@ -45,7 +45,7 @@ module.exports = Refactor =
   applyOne: ->
     buffer =atom.workspace.getActiveTextEditor()
     pos = buffer.getCursorBufferPosition()
-    @applyGen ["--refactor-options=--pos\ #{pos.row + 1},#{pos.column}"]
+    @applyGen ["--refactor-options=--pos\ #{pos.row + 1},#{pos.column + 1}"]
 
   applyAll: -> @applyGen []
 


### PR DESCRIPTION
This fixes the Apply One Suggestion command by converting Atom's 0-based cursor column to refactor's 1-based cursor column.
