### PR TITLE
Apply refactoring changes via diff

### DIFF
--- a/lib/hlint-refactor.coffee
+++ b/lib/hlint-refactor.coffee
@@ -56,7 +56,7 @@ module.exports = Refactor =
     @runCmd(hlintPath,['-'].concat(os),buffer.getText(), "hlint-refact")
     .then (res) =>
       if res.exitCode == 0
-        buffer.setText(res.text)
+        buffer.getBuffer().setTextViaDiff(res.text)
         buffer.setCursorBufferPosition(pos)
       else
         atom.notifications.addError(res.text)


### PR DESCRIPTION
This applies the refactoring changes via a diff, rather than replacing the entire file. Previously, undo/redo were really janky because the entire file would change and you would lose your cursor position.
