### PR TITLE
Keep the trailing newline

### DIFF
--- a/lib/hlint-refactor.coffee
+++ b/lib/hlint-refactor.coffee
@@ -53,11 +53,10 @@ module.exports = Refactor =
     buffer =atom.workspace.getActiveTextEditor()
     pos = buffer.getCursorBufferPosition()
     hlintPath =atom.config.get 'hlint-refactor.hlintPath'
-    hasTrailingNewline = buffer.getText().endsWith("\n")
     @runCmd(hlintPath,['-'].concat(os),buffer.getText(), "hlint-refact")
     .then (res) =>
       if res.exitCode == 0
-        buffer.getBuffer().setTextViaDiff(if hasTrailingNewline then res.text + "\n" else res.text)
+        buffer.getBuffer().setTextViaDiff(res.text)
         buffer.setCursorBufferPosition(pos)
       else
         atom.notifications.addError(res.text)

--- a/lib/hlint-refactor.coffee
+++ b/lib/hlint-refactor.coffee
@@ -53,10 +53,11 @@ module.exports = Refactor =
     buffer =atom.workspace.getActiveTextEditor()
     pos = buffer.getCursorBufferPosition()
     hlintPath =atom.config.get 'hlint-refactor.hlintPath'
+    hasTrailingNewline = buffer.getText().endsWith("\n")
     @runCmd(hlintPath,['-'].concat(os),buffer.getText(), "hlint-refact")
     .then (res) =>
       if res.exitCode == 0
-        buffer.getBuffer().setTextViaDiff(res.text)
+        buffer.getBuffer().setTextViaDiff(if hasTrailingNewline then res.text + "\n" else res.text)
         buffer.setCursorBufferPosition(pos)
       else
         atom.notifications.addError(res.text)

--- a/lib/hlint-refactor.coffee
+++ b/lib/hlint-refactor.coffee
@@ -12,18 +12,18 @@ module.exports = Refactor =
       default: 'refactor'
       description: 'Path to refactor executable'
   runCmd: (path,opts,bufferText, title) ->
-    lines = []
+    chunks = []
     rpath=atom.config.get 'hlint-refactor.refactorPath'
     new Promise (resolve) ->
       bp = new BufferedProcess
         command: path
         args: opts.concat(['--refactor', "--with-refactor=#{rpath}"])
-        stderr: (line) ->
-          lines.push line.slice(0,-1)
-        stdout: (line) ->
-          lines.push line.slice(0,-1)
+        stderr: (chunk) ->
+          chunks.push chunk
+        stdout: (chunk) ->
+          chunks.push chunk
         exit: (code) -> resolve
-          text: lines.join '\n'
+          text: chunks.join('')
           exitCode: code
           title: title
       bp.process.stdin.write(bufferText)


### PR DESCRIPTION
This is a pretty hacky way to keep the trailing newline to avoid undo/redo jankiness, but it's probably a good stopgap. If I understand correctly, the refact library loses this information during refactoring (see https://github.com/mpickering/apply-refact/issues/14).
